### PR TITLE
temp remediation against stackdriver glitches

### DIFF
--- a/src/test/java/com/spotify/autoscaler/AutoscaleJobIT.java
+++ b/src/test/java/com/spotify/autoscaler/AutoscaleJobIT.java
@@ -90,6 +90,7 @@ public class AutoscaleJobIT {
     db = initDatabase(cluster, registry);
     when(bigtableSession.getInstanceAdminClient()).thenReturn(bigtableInstanceClient);
     AutoscaleJobTestMocks.setCurrentSize(bigtableInstanceClient, 100);
+    when(stackdriverClient.getDiskUtilization(any())).thenReturn(new Double(0.00000001));
     job = new AutoscaleJob(bigtableSession, stackdriverClient, cluster, db, registry, clusterStats, () -> Instant.now());
     when(bigtableInstanceClient.updateCluster(any()))
         .thenAnswer(

--- a/src/test/java/com/spotify/autoscaler/AutoscaleJobTest.java
+++ b/src/test/java/com/spotify/autoscaler/AutoscaleJobTest.java
@@ -75,6 +75,7 @@ public class AutoscaleJobTest {
     when(registry.meter(any())).thenReturn(new Meter());
     when(bigtableSession.getInstanceAdminClient()).thenReturn(bigtableInstanceClient);
     AutoscaleJobTestMocks.setCurrentSize(bigtableInstanceClient, 100);
+    when(stackdriverClient.getDiskUtilization(any())).thenReturn(new Double(0.00000001));
     job = new AutoscaleJob(bigtableSession, stackdriverClient, this.cluster, db, registry, clusterStats, () -> Instant.now());
     when(bigtableInstanceClient.updateCluster(any()))
         .thenAnswer(
@@ -215,5 +216,18 @@ public class AutoscaleJobTest {
     AutoscaleJobTestMocks.setCurrentLoad(stackdriverClient, 0.1);
     job.run();
     assertEquals(15, newSize);
+  }
+
+  @Test
+  public void testWeResizeIfStorageConstraintsAreNotMet() {
+    when(stackdriverClient.getDiskUtilization(any())).thenReturn(new Double(0.90));
+    BigtableCluster cluster = BigtableClusterBuilder.from(this.cluster)
+        .lastChange(Instant.now())
+        .build();
+    AutoscaleJobTestMocks.setCurrentSize(bigtableInstanceClient, 5);
+    job = new AutoscaleJob(bigtableSession, stackdriverClient, cluster, db, registry, clusterStats, () -> Instant.now());
+    AutoscaleJobTestMocks.setCurrentLoad(stackdriverClient, 0.1);
+    job.run();
+    assertEquals(7, newSize);
   }
 }


### PR DESCRIPTION
context: yesterday and today, stackdriver reported the storage utilization as 0% for a number of clusters roughly around the same time. That lead to downscaling of clusters that are at storage limits but have a lower cpu utilizations. 

As a quick fix, i changed the code to throw an exception to avoid downscaling if storage <= 0. this of course also avoids upscaling if cpu or size constraints are not met and that is not good either.

plus, i believe we should treat the storage constraint the same as the size (ignoring the frequency constraint if there is a need to upscale because of storage constraints)

@Bj0rnen @borislopezaraoz 