### PR TITLE
Fix test failures in "Getting started" steps

### DIFF
--- a/src/main/java/com/spotify/autoscaler/AutoscaleJobFactory.java
+++ b/src/main/java/com/spotify/autoscaler/AutoscaleJobFactory.java
@@ -25,18 +25,24 @@ import com.spotify.autoscaler.client.StackdriverClient;
 import com.spotify.autoscaler.db.BigtableCluster;
 import com.spotify.autoscaler.db.Database;
 import com.spotify.metrics.core.SemanticMetricRegistry;
+
+import java.io.IOException;
 import java.time.Instant;
 import java.util.function.Supplier;
 
 public class AutoscaleJobFactory {
   public AutoscaleJob createAutoscaleJob(final BigtableSession bigtableSession,
-                                         final StackdriverClient stackdriverClient,
+                                         final IOSupplier<StackdriverClient> stackdriverClient,
                                          final BigtableCluster cluster,
                                          final Database db,
                                          final SemanticMetricRegistry registry,
                                          final ClusterStats clusterStats,
-                                         final Supplier<Instant> timeSource) {
+                                         final Supplier<Instant> timeSource) throws IOException {
     return new AutoscaleJob(
-        bigtableSession, stackdriverClient, cluster, db, registry, clusterStats, timeSource);
+        bigtableSession, stackdriverClient.get(), cluster, db, registry, clusterStats, timeSource);
+  }
+
+  public interface IOSupplier<T> {
+    T get() throws IOException;
   }
 }

--- a/src/main/java/com/spotify/autoscaler/Autoscaler.java
+++ b/src/main/java/com/spotify/autoscaler/Autoscaler.java
@@ -104,7 +104,7 @@ public class Autoscaler implements Runnable {
     logger.info("Autoscaling cluster!");
     try (BigtableSession session = sessionProvider.apply(cluster);
          final AutoscaleJob job = autoscaleJobFactory.createAutoscaleJob(
-             session, new StackdriverClient(cluster), cluster, db, registry,
+             session, () -> new StackdriverClient(cluster), cluster, db, registry,
              clusterStats, Instant::now)) {
       job.run();
     } catch (Exception e) {

--- a/src/test/java/com/spotify/autoscaler/AutoscalerTest.java
+++ b/src/test/java/com/spotify/autoscaler/AutoscalerTest.java
@@ -90,7 +90,7 @@ public class AutoscalerTest {
   }
 
   @Test
-  public void testTwoClustersFoundAndProcessed() {
+  public void testTwoClustersFoundAndProcessed() throws IOException {
     // The main purpose of this test is to ensure that an Autoscale job can process multiple
     // clusters in the same invocation of Autoscaler.run()
 
@@ -129,7 +129,7 @@ public class AutoscalerTest {
   }
 
   @Test
-  public void testTwoClustersFoundOneProcessedOneTakenByAnotherHost() {
+  public void testTwoClustersFoundOneProcessedOneTakenByAnotherHost() throws IOException {
     // The main purpose of this test is to ensure that an Autoscale job is only
     // created (and executed) for cluster1, since although cluster2 passed our filter,
     // another host "raced us first" and processed that cluster.
@@ -155,7 +155,7 @@ public class AutoscalerTest {
   }
 
   @Test
-  public void testTwoClustersFoundOneProcessedOneFilteredOut() {
+  public void testTwoClustersFoundOneProcessedOneFilteredOut() throws IOException {
     // The main purpose of this test is to ensure that
     // updateLastChecked is not run on a cluster that's filtered out
 
@@ -183,7 +183,7 @@ public class AutoscalerTest {
   }
 
   @Test
-  public void testOneClusterThrowsException() {
+  public void testOneClusterThrowsException() throws IOException {
     // The main purpose of this test is to ensure that
     // in cluster fails, later clusters still finish.
 


### PR DESCRIPTION
The first step in our readme, `make build-image` fails because some unit tests are trying to create `StackdriverClient`s.