### PR TITLE
Fixing the current tests that are currently getting a fake connection…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.26</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -217,13 +217,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.7.3</version>
+            <version>1.11.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>1.7.3</version>
+            <version>1.11.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/spotify/autoscaler/db/PostgresDatabase.java
+++ b/src/main/java/com/spotify/autoscaler/db/PostgresDatabase.java
@@ -53,8 +53,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 public class PostgresDatabase implements Database {
 
-  private static final int MAX_POOL_SIZE = 16;
-
   private static final String[] COLUMNS =
       new String[] {
         "project_id",
@@ -103,7 +101,7 @@ public class PostgresDatabase implements Database {
     ds.setJdbcUrl(config.getString("jdbcUrl"));
     ds.setUsername(config.getString("username"));
     ds.setPassword(config.getString("password"));
-    ds.setMaximumPoolSize(MAX_POOL_SIZE);
+    ds.setMaximumPoolSize(config.getInt("maxConnectionPool"));
     ds.setInitializationFailTimeout(-1);
     return ds;
   }

--- a/src/main/resources/bigtable-autoscaler.conf
+++ b/src/main/resources/bigtable-autoscaler.conf
@@ -14,6 +14,7 @@ database {
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     jdbcUrl: ${JDBC_URL}
+    maxConnectionPool: 16
 }
 
 additionalPackages = []

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -69,17 +69,18 @@ CREATE TABLE IF NOT EXISTS resize_log (
 CREATE INDEX ON resize_log(timestamp);
 
 --cluster count limit trigger
-CREATE OR REPLACE FUNCTION enforce_cluster_count_limit() RETURNS trigger AS $$
+CREATE OR REPLACE FUNCTION enforce_cluster_count_limit() RETURNS trigger AS 
+'
 DECLARE
 max_cluster_count INTEGER := 200;
 cluster_count INTEGER := 0;
 must_check BOOLEAN := false;
 BEGIN
-IF TG_OP = 'INSERT' THEN
+IF TG_OP = ''INSERT'' THEN
 must_check := true;
 END IF;
 
-IF TG_OP = 'UPDATE' THEN
+IF TG_OP = ''UPDATE'' THEN
 IF (NEW.enabled = true AND OLD.enabled = false) THEN
 must_check := true;
 END IF;
@@ -94,13 +95,14 @@ FROM autoscale
 WHERE enabled = true;
 
 IF cluster_count >= max_cluster_count THEN
-RAISE EXCEPTION 'Cannot insert more than % clusters.', max_cluster_count;
+RAISE EXCEPTION ''Cannot insert more than % clusters.'', max_cluster_count;
 END IF;
 END IF;
 
 RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+'
+LANGUAGE plpgsql;
 
 DROP TRIGGER IF EXISTS enforce_cluster_count_limit on autoscale;
 CREATE TRIGGER enforce_cluster_count_limit

--- a/src/test/java/com/spotify/autoscaler/AutoscaleJobIT.java
+++ b/src/test/java/com/spotify/autoscaler/AutoscaleJobIT.java
@@ -40,7 +40,6 @@ import com.spotify.autoscaler.util.ErrorCode;
 import com.spotify.metrics.core.SemanticMetricRegistry;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import com.typesafe.config.ConfigValueFactory;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -61,6 +60,8 @@ import org.testcontainers.containers.PostgreSQLContainer;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class AutoscaleJobIT {
+  private static final String SERVICE_NAME = "bigtable-autoscaler";
+
   @ClassRule public static PostgreSQLContainer pg = new PostgreSQLContainer();
 
   @Mock BigtableSession bigtableSession;
@@ -127,13 +128,9 @@ public class AutoscaleJobIT {
 
   private static Database initDatabase(BigtableCluster cluster, SemanticMetricRegistry registry)
       throws SQLException, IOException {
-    Config config =
-        ConfigFactory.empty()
-            .withValue("jdbcUrl", ConfigValueFactory.fromAnyRef(pg.getJdbcUrl()))
-            .withValue("username", ConfigValueFactory.fromAnyRef(pg.getUsername()))
-            .withValue("password", ConfigValueFactory.fromAnyRef(pg.getPassword()));
+    Config config = ConfigFactory.load(SERVICE_NAME);
 
-    Database db = new PostgresDatabase(config, registry);
+    Database db = new PostgresDatabase(config.getConfig("database"), registry);
     db.deleteBigtableCluster(cluster.projectId(), cluster.instanceId(), cluster.clusterId());
     db.insertBigtableCluster(cluster);
     return db;

--- a/src/test/java/com/spotify/autoscaler/AutoscalerTest.java
+++ b/src/test/java/com/spotify/autoscaler/AutoscalerTest.java
@@ -114,7 +114,7 @@ public class AutoscalerTest {
     when(database.updateLastChecked(cluster1)).thenReturn(true).thenReturn(false);
     when(database.updateLastChecked(cluster2)).thenReturn(true).thenReturn(false);
 
-    final Autoscaler autoscaler =
+    Autoscaler autoscaler =
         new Autoscaler(
             autoscaleJobFactory,
             executorService,
@@ -136,7 +136,7 @@ public class AutoscalerTest {
     verify(database).updateLastChecked(cluster2);
 
     // Clusters should be checked in order since the unit test uses DirectExecutor executorservice
-    final InOrder inOrder = inOrder(autoscaleJobFactory);
+    InOrder inOrder = inOrder(autoscaleJobFactory);
     inOrder
         .verify(autoscaleJobFactory)
         .createAutoscaleJob(any(), any(), eq(cluster1), any(), any(), any(), any());
@@ -159,7 +159,7 @@ public class AutoscalerTest {
         .thenReturn(false); // Simulate this cluster was "taken" by another host
     when(database.updateLastChecked(cluster2)).thenReturn(true).thenReturn(false);
 
-    final Autoscaler autoscaler =
+    Autoscaler autoscaler =
         new Autoscaler(
             autoscaleJobFactory,
             executorService,
@@ -186,7 +186,7 @@ public class AutoscalerTest {
     when(database.getCandidateClusters()).thenReturn(Arrays.asList(cluster1, cluster2));
     when(database.updateLastChecked(cluster2)).thenReturn(true).thenReturn(false);
 
-    final Autoscaler autoscaler =
+    Autoscaler autoscaler =
         new Autoscaler(
             autoscaleJobFactory,
             executorService,
@@ -222,7 +222,7 @@ public class AutoscalerTest {
             any(), any(), eq(cluster1), any(), any(), any(), any()))
         .thenThrow(new RuntimeException("cluster1"));
 
-    final Autoscaler autoscaler =
+    Autoscaler autoscaler =
         new Autoscaler(
             autoscaleJobFactory,
             executorService,

--- a/src/test/java/com/spotify/autoscaler/AutoscalerTest.java
+++ b/src/test/java/com/spotify/autoscaler/AutoscalerTest.java
@@ -38,6 +38,7 @@ import com.spotify.autoscaler.db.BigtableCluster;
 import com.spotify.autoscaler.db.BigtableClusterBuilder;
 import com.spotify.autoscaler.db.Database;
 import com.spotify.autoscaler.filters.AllowAllClusterFilter;
+import com.spotify.autoscaler.filters.ClusterFilter;
 import com.spotify.autoscaler.util.ErrorCode;
 import com.spotify.metrics.core.SemanticMetricRegistry;
 import java.io.IOException;
@@ -95,6 +96,18 @@ public class AutoscalerTest {
           .errorCode(Optional.of(ErrorCode.OK))
           .build();
 
+  private Autoscaler getAutoscaler(final ClusterFilter cluster) {
+    return new Autoscaler(
+        autoscaleJobFactory,
+        executorService,
+        registry,
+        stackDriverClient,
+        database,
+        sessionProvider,
+        clusterStats,
+        cluster);
+  }
+
   @Before
   public void setUp() throws IOException {
     initMocks(this);
@@ -114,16 +127,7 @@ public class AutoscalerTest {
     when(database.updateLastChecked(cluster1)).thenReturn(true).thenReturn(false);
     when(database.updateLastChecked(cluster2)).thenReturn(true).thenReturn(false);
 
-    Autoscaler autoscaler =
-        new Autoscaler(
-            autoscaleJobFactory,
-            executorService,
-            registry,
-            stackDriverClient,
-            database,
-            sessionProvider,
-            clusterStats,
-            new AllowAllClusterFilter());
+    final Autoscaler autoscaler = getAutoscaler(new AllowAllClusterFilter());
 
     autoscaler.run();
 
@@ -136,7 +140,7 @@ public class AutoscalerTest {
     verify(database).updateLastChecked(cluster2);
 
     // Clusters should be checked in order since the unit test uses DirectExecutor executorservice
-    InOrder inOrder = inOrder(autoscaleJobFactory);
+    final InOrder inOrder = inOrder(autoscaleJobFactory);
     inOrder
         .verify(autoscaleJobFactory)
         .createAutoscaleJob(any(), any(), eq(cluster1), any(), any(), any(), any());
@@ -159,16 +163,7 @@ public class AutoscalerTest {
         .thenReturn(false); // Simulate this cluster was "taken" by another host
     when(database.updateLastChecked(cluster2)).thenReturn(true).thenReturn(false);
 
-    Autoscaler autoscaler =
-        new Autoscaler(
-            autoscaleJobFactory,
-            executorService,
-            registry,
-            stackDriverClient,
-            database,
-            sessionProvider,
-            clusterStats,
-            new AllowAllClusterFilter());
+    final Autoscaler autoscaler = getAutoscaler(new AllowAllClusterFilter());
 
     autoscaler.run();
 
@@ -186,16 +181,7 @@ public class AutoscalerTest {
     when(database.getCandidateClusters()).thenReturn(Arrays.asList(cluster1, cluster2));
     when(database.updateLastChecked(cluster2)).thenReturn(true).thenReturn(false);
 
-    Autoscaler autoscaler =
-        new Autoscaler(
-            autoscaleJobFactory,
-            executorService,
-            registry,
-            stackDriverClient,
-            database,
-            sessionProvider,
-            clusterStats,
-            cluster -> cluster.clusterId().equals("cluster2"));
+    final Autoscaler autoscaler = getAutoscaler(cluster -> cluster.clusterId().equals("cluster2"));
 
     autoscaler.run();
 
@@ -222,16 +208,7 @@ public class AutoscalerTest {
             any(), any(), eq(cluster1), any(), any(), any(), any()))
         .thenThrow(new RuntimeException("cluster1"));
 
-    Autoscaler autoscaler =
-        new Autoscaler(
-            autoscaleJobFactory,
-            executorService,
-            registry,
-            stackDriverClient,
-            database,
-            sessionProvider,
-            clusterStats,
-            new AllowAllClusterFilter());
+    final Autoscaler autoscaler = getAutoscaler(new AllowAllClusterFilter());
 
     autoscaler.run();
 

--- a/src/test/java/com/spotify/autoscaler/db/PostgresDatabaseTest.java
+++ b/src/test/java/com/spotify/autoscaler/db/PostgresDatabaseTest.java
@@ -1,0 +1,54 @@
+/*-
+ * -\-\-
+ * bigtable-autoscaler
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.autoscaler.db;
+
+import static org.mockito.Mockito.mock;
+
+import com.spotify.metrics.core.SemanticMetricRegistry;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class PostgresDatabaseTest {
+
+  /*
+  Obs: By default database container is being stopped as soon as last connection is closed.
+  So, we don't need to be worried about the containers closing, apparently.
+  However, the db connection should be closed.
+  */
+
+  public static PostgresDatabase getPostgresDatabase() {
+    JdbcDatabaseContainer container = new PostgreSQLContainer().withInitScript("schema.sql");
+    container.start();
+    Config config =
+        ConfigFactory.empty()
+            .withValue("jdbcUrl", ConfigValueFactory.fromAnyRef(container.getJdbcUrl()))
+            .withValue("username", ConfigValueFactory.fromAnyRef(container.getUsername()))
+            .withValue("password", ConfigValueFactory.fromAnyRef(container.getPassword()))
+            .withValue("maxConnectionPool", ConfigValueFactory.fromAnyRef(1));
+    SemanticMetricRegistry registry = mock(SemanticMetricRegistry.class);
+    PostgresDatabase db = new PostgresDatabase(config, registry);
+
+    return db;
+  }
+}


### PR DESCRIPTION
… instead of the provided in the conf file.

before we were getting a PSQLException: Connection to localhost:32782 refused. on those tests.

As we can see in the logs, even though we are getting a SUCCESS message in the end, the same exception is appearing on these tests.
https://circleci.com/gh/spotify/bigtable-autoscaler/222#tests/containers/0