### PR TITLE
Refactor metrics

### DIFF
--- a/src/main/java/com/spotify/autoscaler/AutoscaleJob.java
+++ b/src/main/java/com/spotify/autoscaler/AutoscaleJob.java
@@ -32,6 +32,7 @@ import com.spotify.autoscaler.client.StackdriverClient;
 import com.spotify.autoscaler.db.BigtableCluster;
 import com.spotify.autoscaler.db.ClusterResizeLogBuilder;
 import com.spotify.autoscaler.db.Database;
+import com.spotify.autoscaler.metric.BigtableMetric;
 import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
 import java.io.Closeable;
@@ -202,7 +203,7 @@ public class AutoscaleJob implements Closeable {
     try {
       currentCpu = getCurrentCpu(samplingDuration);
     } finally {
-      clusterStats.setLoad(cluster, currentCpu, ClusterStats.MetricType.CPU);
+      clusterStats.setLoad(cluster, currentCpu, BigtableMetric.MetricType.CPU);
     }
 
     logger.info(
@@ -279,7 +280,7 @@ public class AutoscaleJob implements Closeable {
     try {
       storageUtilization = stackdriverClient.getDiskUtilization(cluster, samplingDuration);
     } finally {
-      clusterStats.setLoad(cluster, storageUtilization, ClusterStats.MetricType.STORAGE);
+      clusterStats.setLoad(cluster, storageUtilization, BigtableMetric.MetricType.STORAGE);
     }
     if (storageUtilization <= 0.0) {
       return Math.max(currentNodes, desiredNodes);

--- a/src/main/java/com/spotify/autoscaler/AutoscaleJob.java
+++ b/src/main/java/com/spotify/autoscaler/AutoscaleJob.java
@@ -203,7 +203,7 @@ public class AutoscaleJob implements Closeable {
     try {
       currentCpu = getCurrentCpu(samplingDuration);
     } finally {
-      clusterStats.setLoad(cluster, currentCpu, BigtableMetric.MetricType.CPU);
+      clusterStats.setLoad(cluster, currentCpu, BigtableMetric.LoadMetricType.CPU);
     }
 
     logger.info(
@@ -280,7 +280,7 @@ public class AutoscaleJob implements Closeable {
     try {
       storageUtilization = stackdriverClient.getDiskUtilization(cluster, samplingDuration);
     } finally {
-      clusterStats.setLoad(cluster, storageUtilization, BigtableMetric.MetricType.STORAGE);
+      clusterStats.setLoad(cluster, storageUtilization, BigtableMetric.LoadMetricType.STORAGE);
     }
     if (storageUtilization <= 0.0) {
       return Math.max(currentNodes, desiredNodes);

--- a/src/main/java/com/spotify/autoscaler/ClusterData.java
+++ b/src/main/java/com/spotify/autoscaler/ClusterData.java
@@ -1,0 +1,120 @@
+/*-
+ * -\-\-
+ * bigtable-autoscaler
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.autoscaler;
+
+import com.spotify.autoscaler.db.BigtableCluster;
+import com.spotify.autoscaler.util.ErrorCode;
+import java.util.Optional;
+
+public class ClusterData {
+
+  private BigtableCluster cluster;
+  private int currentNodeCount;
+  private int minNodeCount;
+  private int maxNodeCount;
+  private int effectiveMinNodeCount;
+  private double cpuUtil;
+  private int consecutiveFailureCount;
+  private double storageUtil;
+  private Optional<ErrorCode> lastErrorCode;
+
+  public int getCurrentNodeCount() {
+    return currentNodeCount;
+  }
+
+  public int getConsecutiveFailureCount() {
+    return consecutiveFailureCount;
+  }
+
+  public double getCpuUtil() {
+    return cpuUtil;
+  }
+
+  public Optional<ErrorCode> getLastErrorCode() {
+    return lastErrorCode;
+  }
+
+  public void setCurrentNodeCount(final int currentNodeCount) {
+    this.currentNodeCount = currentNodeCount;
+  }
+
+  public void setConsecutiveFailureCount(final int consecutiveFailureCount) {
+    this.consecutiveFailureCount = consecutiveFailureCount;
+  }
+
+  public void setLastErrorCode(final Optional<ErrorCode> lastErrorCode) {
+    this.lastErrorCode = lastErrorCode;
+  }
+
+  public double getStorageUtil() {
+    return storageUtil;
+  }
+
+  public void setStorageUtil(double storageUtil) {
+    this.storageUtil = storageUtil;
+  }
+
+  public void setCpuUtil(double cpuUtil) {
+    this.cpuUtil = cpuUtil;
+  }
+
+  public BigtableCluster getCluster() {
+    return cluster;
+  }
+
+  public ClusterData(
+      final BigtableCluster cluster,
+      final int currentNodeCount,
+      final int consecutiveFailureCount,
+      final Optional<ErrorCode> lastErrorCode) {
+    this.currentNodeCount = currentNodeCount;
+    this.minNodeCount = cluster.minNodes();
+    this.maxNodeCount = cluster.maxNodes();
+    this.effectiveMinNodeCount = cluster.effectiveMinNodes();
+    this.cluster = cluster;
+    this.consecutiveFailureCount = consecutiveFailureCount;
+    this.lastErrorCode = lastErrorCode;
+  }
+
+  public int getMaxNodeCount() {
+    return maxNodeCount;
+  }
+
+  public void setMaxNodeCount(int maxNodeCount) {
+    this.maxNodeCount = maxNodeCount;
+  }
+
+  public int getMinNodeCount() {
+    return minNodeCount;
+  }
+
+  public void setMinNodeCount(int minNodeCount) {
+    this.minNodeCount = minNodeCount;
+  }
+
+  public int getEffectiveMinNodeCount() {
+    return effectiveMinNodeCount;
+  }
+
+  public void setEffectiveMinNodeCount(int effectiveMinNodeCount) {
+    this.effectiveMinNodeCount = effectiveMinNodeCount;
+  }
+}

--- a/src/main/java/com/spotify/autoscaler/ClusterData.java
+++ b/src/main/java/com/spotify/autoscaler/ClusterData.java
@@ -25,7 +25,6 @@ import com.spotify.autoscaler.util.ErrorCode;
 import java.util.Optional;
 
 public class ClusterData {
-
   private BigtableCluster cluster;
   private int currentNodeCount;
   private int minNodeCount;
@@ -78,6 +77,10 @@ public class ClusterData {
 
   public BigtableCluster getCluster() {
     return cluster;
+  }
+
+  public void setCluster(final BigtableCluster cluster) {
+    this.cluster = cluster;
   }
 
   public ClusterData(

--- a/src/main/java/com/spotify/autoscaler/ClusterStats.java
+++ b/src/main/java/com/spotify/autoscaler/ClusterStats.java
@@ -289,9 +289,6 @@ public class ClusterStats {
   }
 
   public <T extends Metric> T registerMetric(String what, BigtableCluster cluster, T metric) {
-    System.out.println("what = " + what);
-    System.out.println("cluster = " + cluster.clusterName());
-    System.out.println("metric = " + metric.toString());
     return this.registry.register(
         APP_PREFIX
             .tagged("what", what)

--- a/src/main/java/com/spotify/autoscaler/ClusterStats.java
+++ b/src/main/java/com/spotify/autoscaler/ClusterStats.java
@@ -107,9 +107,6 @@ public class ClusterStats {
       // First time we saw this cluster, register a gauge
 
       for (BigtableMetric.Metrics metric : BigtableMetric.Metrics.values()) {
-        // This will return null for non implemented getMetricValues. This will happen when the
-        // metric depends in other things other than the registeredClusters or the cluster
-        // itself, e.g., when it is dependent on the database.
         Gauge metricValue =
             metric.getMetricValue(registeredClusters.get(cluster.clusterName()), db);
         registerMetric(metric.tag, cluster, metricValue);

--- a/src/main/java/com/spotify/autoscaler/ClusterStats.java
+++ b/src/main/java/com/spotify/autoscaler/ClusterStats.java
@@ -135,6 +135,7 @@ public class ClusterStats {
       clusterData.setMinNodeCount(cluster.minNodes());
       clusterData.setMaxNodeCount(cluster.maxNodes());
       clusterData.setEffectiveMinNodeCount(cluster.effectiveMinNodes());
+      clusterData.setCluster(cluster);
     }
   }
 

--- a/src/main/java/com/spotify/autoscaler/metric/BigtableMetric.java
+++ b/src/main/java/com/spotify/autoscaler/metric/BigtableMetric.java
@@ -20,8 +20,11 @@
 
 package com.spotify.autoscaler.metric;
 
+import com.codahale.metrics.Gauge;
+import com.spotify.autoscaler.ClusterData;
 import java.util.ArrayList;
 import java.util.List;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class BigtableMetric {
 
@@ -30,8 +33,8 @@ public class BigtableMetric {
     for (Metrics metric : Metrics.values()) {
       metrics.add(metric.tag);
     }
-    for (MetricType metricType : MetricType.values()) {
-      metrics.add(metricType.tag);
+    for (LoadMetricType loadMetricType : LoadMetricType.values()) {
+      metrics.add(loadMetricType.tag);
     }
     for (ErrorCode errorCode : ErrorCode.values()) {
       metrics.add(errorCode.tag);
@@ -40,27 +43,61 @@ public class BigtableMetric {
   }
 
   public enum Metrics {
-    NODE_COUNT("node-count"),
-    MIN_NODE_COUNT("min-node-count"),
-    MAX_NODE_COUNT("max-node-count"),
-    EFFECTIVE_MIN_NODE_COUNT("effective-min-node-count"),
-    LAST_CHECK_TIME("last-check-time"),
-    CPU_TARGET_RATIO("cpu-target-ratio");
+    NODE_COUNT("node-count") {
+      @Override
+      public Gauge getMetricValue(final ClusterData clusterData) {
+        return clusterData::getCurrentNodeCount;
+      }
+    },
+    MIN_NODE_COUNT("min-node-count") {
+      @Override
+      public Gauge getMetricValue(final ClusterData clusterData) {
+        return clusterData::getMinNodeCount;
+      }
+    },
+    MAX_NODE_COUNT("max-node-count") {
+      @Override
+      public Gauge getMetricValue(final ClusterData clusterData) {
+        return clusterData::getMaxNodeCount;
+      }
+    },
+    EFFECTIVE_MIN_NODE_COUNT("effective-min-node-count") {
+      @Override
+      public Gauge getMetricValue(final ClusterData clusterData) {
+        return clusterData::getEffectiveMinNodeCount;
+      }
+    },
+    LAST_CHECK_TIME("last-check-time") {
+      @Override
+      public Gauge getMetricValue(final ClusterData clusterData) {
+        return null;
+      }
+    },
+    CPU_TARGET_RATIO("cpu-target-ratio") {
+      @Override
+      public Gauge getMetricValue(final ClusterData clusterData) {
+        return null;
+      }
+    };
 
     public String tag;
 
     Metrics(final String tag) {
       this.tag = tag;
     }
+
+    public Gauge getMetricValue(final ClusterData clusterData) {
+      throw new NotImplementedException();
+    }
   }
 
-  public enum MetricType {
+  public enum LoadMetricType {
     CPU("cpu-util"),
     STORAGE("storage-util");
 
     public String tag;
 
-    MetricType(final String tag) {
+    LoadMetricType(final String tag) {
       this.tag = tag;
     }
   }

--- a/src/main/java/com/spotify/autoscaler/metric/BigtableMetric.java
+++ b/src/main/java/com/spotify/autoscaler/metric/BigtableMetric.java
@@ -28,7 +28,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class BigtableMetric {
 

--- a/src/main/java/com/spotify/autoscaler/metric/BigtableMetric.java
+++ b/src/main/java/com/spotify/autoscaler/metric/BigtableMetric.java
@@ -48,31 +48,26 @@ public class BigtableMetric {
 
   public enum Metrics {
     NODE_COUNT("node-count") {
-      @Override
       public Gauge getMetricValue(final ClusterData clusterData, final Database db) {
         return clusterData::getCurrentNodeCount;
       }
     },
     MIN_NODE_COUNT("min-node-count") {
-      @Override
       public Gauge getMetricValue(final ClusterData clusterData, final Database db) {
         return clusterData::getMinNodeCount;
       }
     },
     MAX_NODE_COUNT("max-node-count") {
-      @Override
       public Gauge getMetricValue(final ClusterData clusterData, final Database db) {
         return clusterData::getMaxNodeCount;
       }
     },
     EFFECTIVE_MIN_NODE_COUNT("effective-min-node-count") {
-      @Override
       public Gauge getMetricValue(final ClusterData clusterData, final Database db) {
         return clusterData::getEffectiveMinNodeCount;
       }
     },
     LAST_CHECK_TIME("last-check-time") {
-      @Override
       public Gauge getMetricValue(final ClusterData clusterData, final Database db) {
         return () ->
             db.getBigtableCluster(
@@ -88,7 +83,6 @@ public class BigtableMetric {
       }
     },
     CPU_TARGET_RATIO("cpu-target-ratio") {
-      @Override
       public Gauge getMetricValue(final ClusterData clusterData, final Database db) {
         return () -> clusterData.getCpuUtil() / clusterData.getCluster().cpuTarget();
       }
@@ -100,9 +94,7 @@ public class BigtableMetric {
       this.tag = tag;
     }
 
-    public Gauge getMetricValue(final ClusterData clusterData, final Database db) {
-      throw new NotImplementedException();
-    }
+    public abstract Gauge getMetricValue(final ClusterData clusterData, final Database db);
   }
 
   public enum LoadMetricType {

--- a/src/main/java/com/spotify/autoscaler/metric/BigtableMetric.java
+++ b/src/main/java/com/spotify/autoscaler/metric/BigtableMetric.java
@@ -1,0 +1,77 @@
+/*-
+ * -\-\-
+ * bigtable-autoscaler
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.autoscaler.metric;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BigtableMetric {
+
+  public static List<String> getAllMetrics() {
+    List<String> metrics = new ArrayList<>();
+    for (Metrics metric : Metrics.values()) {
+      metrics.add(metric.tag);
+    }
+    for (MetricType metricType : MetricType.values()) {
+      metrics.add(metricType.tag);
+    }
+    for (ErrorCode errorCode : ErrorCode.values()) {
+      metrics.add(errorCode.tag);
+    }
+    return metrics;
+  }
+
+  public enum Metrics {
+    NODE_COUNT("node-count"),
+    MIN_NODE_COUNT("min-node-count"),
+    MAX_NODE_COUNT("max-node-count"),
+    EFFECTIVE_MIN_NODE_COUNT("effective-min-node-count"),
+    LAST_CHECK_TIME("last-check-time"),
+    CPU_TARGET_RATIO("cpu-target-ratio");
+
+    public String tag;
+
+    Metrics(final String tag) {
+      this.tag = tag;
+    }
+  }
+
+  public enum MetricType {
+    CPU("cpu-util"),
+    STORAGE("storage-util");
+
+    public String tag;
+
+    MetricType(final String tag) {
+      this.tag = tag;
+    }
+  }
+
+  public enum ErrorCode {
+    CONSECUTIVE_FAILURE_COUNT("consecutive-failure-count");
+
+    public String tag;
+
+    ErrorCode(final String tag) {
+      this.tag = tag;
+    }
+  }
+}


### PR DESCRIPTION
This change is refactoring the way we handle the metrics.
A new class was created: NigtableMetric
The metric names (tags) was centralized in this class, and the code was refactored to make the flow of registering and unregistering metrics dependent only of the values setted there.
Consequently, any new metric to be added, or metric to be removed, we are forced to add in the BigtableMetric, and the flow for unregistering it is already fulfilled, you just need to add the registering logic (that was also simplified, adding the new metric in the switch case).