### PR TITLE
min nodes override should not go below its starting point

### DIFF
--- a/src/main/java/com/spotify/autoscaler/db/PostgresDatabase.java
+++ b/src/main/java/com/spotify/autoscaler/db/PostgresDatabase.java
@@ -439,7 +439,8 @@ public class PostgresDatabase implements Database {
             + "min_nodes_override = case "
             + "                         when :new_load_delta = 0 then null"
             + "                         when load_delta = :new_load_delta then min_nodes_override "
-            + "                         else :current_node_count + :new_load_delta - load_delta "
+            + "                         else GREATEST(min_nodes_override, :current_node_count) + "
+            + ":new_load_delta - load_delta "
             + "                       end "
             + "WHERE project_id = :project_id AND instance_id = :instance_id AND cluster_id = "
             + ":cluster_id";

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -44,7 +44,8 @@ CREATE TABLE IF NOT EXISTS autoscale (
     CONSTRAINT autoscale_min_nodes_check CHECK ((min_nodes >= 3)),
     CONSTRAINT autoscale_overload_step_check1 CHECK (((overload_step > 0) OR (overload_step IS
     NULL))),
-    CONSTRAINT autoscale_max_nodes_check CHECK(max_nodes >= min_nodes)
+    CONSTRAINT autoscale_max_nodes_check CHECK(max_nodes >= min_nodes),
+    CONSTRAINT min_nodes_override_check CHECK(min_nodes_override>0)
 );
 
 

--- a/src/test/java/com/spotify/autoscaler/simulation/FakeBTCluster.java
+++ b/src/test/java/com/spotify/autoscaler/simulation/FakeBTCluster.java
@@ -123,7 +123,9 @@ public class FakeBTCluster {
             ? Optional.empty()
             : loadDeltaDiff == 0
                 ? cluster.minNodesOverride()
-                : Optional.of(nodes + (loadDelta - cluster.loadDelta()));
+                : Optional.of(
+                    Math.max(nodes, cluster.minNodesOverride().orElse(nodes))
+                        + (loadDelta - cluster.loadDelta()));
     this.cluster =
         BigtableClusterBuilder.from(cluster)
             .loadDelta(loadDelta)


### PR DESCRIPTION
This will solve these two cases:

Case 1 (when effective min nodes is capped by max nodes):
   -  min nodes = 3, max nodes = 10
   - load delta = 20 --> min nodes override = 23, effective min = 10, current = 10
   - load delta = 40 --> min nodes override (current + load delta difference) = 30, effective min = current = 10
   - load delta = 20 --> min nodes override = -10 

Case 2(when load delta is updated twice before autoscaler could scale up):
 -  current nodes = 10
 - load delta = 20 --> min nodes override = 30
- load delta = 40 --> min nodes override (current + load delta difference) = 30


    