### PR TITLE
Update make run to use docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ down:
 
 # run only the service container (pointing to your own postgresql)
 run:
-	docker run --name $(SERVICE_NAME) --detach --env-file .env --rm $(SERVICE_IMAGE_TAG)
+	docker-compose run --name $(SERVICE_NAME) --detach --no-deps --rm $(SERVICE_NAME)
 
 # stop service container only
 stop:

--- a/README.md
+++ b/README.md
@@ -68,9 +68,12 @@ state. We recommend connecting using the [JDBC socket factory](https://cloud.goo
 
 Just update [.env](.env) with your postgres url, user and password and then run:
 
+    # source your environment
+    . ./.env
+    # start the service with docker compose
     make run
 
-This uses the same image but only with docker (no docker-compose) and points to the postgresql you provided.
+This runs the same bigtable-autoscaler image, doesn't run postgres, and points bigtable-autoscaler to the postgresql you provided.
 
 In the same way you can see service logs (make logs) and then to stop the service:
 


### PR DESCRIPTION
This will make sure the container has the right `GOOGLE_APPLICATION_CREDENTIALS` set.  (see: issue #112 )

