### PR TITLE
database migrations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
   postgres:
     image: postgres:9.6
     restart: always
-    volumes:
-      - ./src/main/resources/schema.sql:/docker-entrypoint-initdb.d/1-create-schema.sql
     environment:
       POSTGRES_DB: autoscaler
       POSTGRES_PASSWORD: ${DB_PASSWORD}

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,11 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <version>7.3.1</version>
+        </dependency>
 
         <!-- test scope -->
         <dependency>

--- a/quickstart.yml
+++ b/quickstart.yml
@@ -5,8 +5,6 @@ services:
   postgres:
     image: postgres:9.6
     restart: always
-    volumes:
-      - ./src/main/resources/schema.sql:/docker-entrypoint-initdb.d/1-create-schema.sql
     environment:
       POSTGRES_DB: autoscaler
 

--- a/src/main/java/com/spotify/autoscaler/Application.java
+++ b/src/main/java/com/spotify/autoscaler/Application.java
@@ -20,6 +20,7 @@
 
 package com.spotify.autoscaler;
 
+import com.spotify.autoscaler.db.Database;
 import com.spotify.metrics.ffwd.FastForwardReporter;
 import java.io.IOException;
 import java.time.Duration;
@@ -40,19 +41,23 @@ public class Application {
   private final Autoscaler autoscaler;
   private final HttpServer server;
   private final Optional<FastForwardReporter> reporter;
+  private final Database database;
   private static final Duration RUN_INTERVAL = Duration.ofSeconds(15);
 
   @Inject
   public Application(
       final Autoscaler autoscaler,
       final HttpServer server,
-      final Optional<FastForwardReporter> reporter) {
+      final Optional<FastForwardReporter> reporter,
+      final Database database) {
     this.autoscaler = autoscaler;
     this.server = server;
     this.reporter = reporter;
+    this.database = database;
   }
 
   public void start() throws IOException {
+    database.migrate();
     reporter.ifPresent(FastForwardReporter::start);
     scheduledExecutorService.scheduleWithFixedDelay(
         autoscaler, RUN_INTERVAL.toMillis(), RUN_INTERVAL.toMillis(), TimeUnit.MILLISECONDS);

--- a/src/main/java/com/spotify/autoscaler/db/Database.java
+++ b/src/main/java/com/spotify/autoscaler/db/Database.java
@@ -91,4 +91,6 @@ public interface Database extends AutoCloseable {
       String projectId, String instanceId, Set<String> excludedClusterIds);
 
   void reconcileBigtableCluster(final BigtableCluster cluster);
+
+  void migrate();
 }

--- a/src/main/java/com/spotify/autoscaler/db/PostgresDatabase.java
+++ b/src/main/java/com/spotify/autoscaler/db/PostgresDatabase.java
@@ -44,6 +44,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+import org.flywaydb.core.Flyway;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 public class PostgresDatabase implements Database {
@@ -475,5 +476,10 @@ public class PostgresDatabase implements Database {
       params.put("cluster_ids", clusterIds);
     }
     return jdbc.update(sql.toString(), params);
+  }
+
+  @Override
+  public void migrate() {
+    Flyway.configure().dataSource(dataSource).envVars().load().migrate();
   }
 }

--- a/src/main/resources/db/migration/V1__schema.sql
+++ b/src/main/resources/db/migration/V1__schema.sql
@@ -73,9 +73,3 @@ CREATE TABLE IF NOT EXISTS resize_log (
 
 CREATE INDEX ON resize_log(timestamp);
 
-ALTER TABLE autoscale ADD COLUMN IF NOT EXISTS storage_target double precision NOT NULL default(0.7);
-ALTER TABLE resize_log ADD COLUMN IF NOT EXISTS storage_target double precision NOT NULL default(0.7);
-ALTER TABLE autoscale DROP CONSTRAINT IF EXISTS autoscale_storage_target_check;
-ALTER TABLE autoscale ADD CONSTRAINT autoscale_storage_target_check CHECK ((storage_target > (0.0)::double precision));
-ALTER TABLE autoscale DROP CONSTRAINT IF EXISTS autoscale_storage_target_check1;
-ALTER TABLE autoscale ADD CONSTRAINT autoscale_storage_target_check1 CHECK ((storage_target < (1.0)::double precision));

--- a/src/test/java/com/spotify/autoscaler/db/PostgresDatabaseTest.java
+++ b/src/test/java/com/spotify/autoscaler/db/PostgresDatabaseTest.java
@@ -35,7 +35,7 @@ public class PostgresDatabaseTest {
   */
 
   public static PostgresDatabase getPostgresDatabase() {
-    JdbcDatabaseContainer container = new PostgreSQLContainer().withInitScript("schema.sql");
+    JdbcDatabaseContainer container = new PostgreSQLContainer();
     container.start();
     Config config =
         ConfigFactory.empty()
@@ -44,6 +44,8 @@ public class PostgresDatabaseTest {
             .withValue("password", ConfigValueFactory.fromAnyRef(container.getPassword()))
             .withValue("maxConnectionPool", ConfigValueFactory.fromAnyRef(1));
 
-    return new PostgresDatabase(config);
+    PostgresDatabase postgresDatabase = new PostgresDatabase(config);
+    postgresDatabase.migrate();
+    return postgresDatabase;
   }
 }


### PR DESCRIPTION
This PR uses [flyway](https://flywaydb.org/) to run database migrations on startup.